### PR TITLE
Accepts any directory starting with VimTAP

### DIFF
--- a/bin/runVimTestsSetup.vim
+++ b/bin/runVimTestsSetup.vim
@@ -4,7 +4,8 @@
 let &runtimepath = expand('<sfile>:p:h:h') . ',' . &runtimepath
 
 " Use VimTAP from a repository next to runVimTests (if available).
-let s:VimTAPRepositoryDirspec = expand('<sfile>:p:h:h:h') . '/VimTAP'
+let s:VimTAPRepositoryDirspec = substitute(
+    \ glob(expand('<sfile>:p:h:h:h') . '/VimTAP*'), "\n.*", '', '')
 if isdirectory(s:VimTAPRepositoryDirspec)
     let &runtimepath = s:VimTAPRepositoryDirspec . ',' . &runtimepath
 endif


### PR DESCRIPTION
I've just updated runVimTests and noticed that now it tries to detect the the VimTAP and runVimTests itself automatically, which is very nice.

While this works fine for `bundle/VimTAP`, it fails if the directory name is different, as `bundle/VimTAP-0.3/`. I prefer to keep the prefix to remind me that it is not the latest version of the plugin, as it is not in github.