### PR TITLE
cd might print the path when CDPATH is set, discard it.

### DIFF
--- a/bin/runVimTests.sh
+++ b/bin/runVimTests.sh
@@ -642,7 +642,7 @@ runTest()
     fi
     local -r testDirspec=$(dirname -- "$1")
     local -r testFile=$(basename -- "$1")
-    local -r testFilespec=$(cd "$testDirspec" && echo "${PWD}/${testFile}") || { echo >&2 "ERROR: Cannot determine absolute filespec!"; exit 3; }
+    local -r testFilespec=$(cd "$testDirspec" > /dev/null && echo "${PWD}/${testFile}") || { echo >&2 "ERROR: Cannot determine absolute filespec!"; exit 3; }
     local -r testName=${testFile%.*}
 
     # The setup script is not a test, silently skip it.


### PR DESCRIPTION
From `man bash`:
>If a non-empty directory name from CDPATH is used, or if - is the first argument, and the directory change is successful, the absolute pathname of the new working directory is written to the standard output.

When cd prints the path the path ends up being duplicate in testFilespec.